### PR TITLE
Set up theme for variant A cookie banner

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "wpackagist-plugin/classic-editor": "*",
         "ministryofjustice/wp-rewrite-media-to-s3": "^0.1.1",
         "wpackagist-plugin/option-tree": "*",
-        "ministryofjustice/cookie-compliance-for-wordpress": "*",
+        "ministryofjustice/cookie-compliance-for-wordpress": "dev-variant-a",
         "ministryofjustice/wp-user-roles": "*",
         "ministryofjustice/wp-moj-components": "*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "939cb106774c63a909b716e52bf90506",
+    "content-hash": "5492263aab8dc60d9ad018d0934403b6",
     "packages": [
         {
             "name": "composer/installers",
@@ -307,17 +307,17 @@
         },
         {
             "name": "ministryofjustice/cookie-compliance-for-wordpress",
-            "version": "1.3.2",
+            "version": "dev-variant-a",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ministryofjustice/cookie-compliance-for-wordpress.git",
-                "reference": "cb04cfb9e912d780f176747dbd6796fb0741f738"
+                "reference": "ee7d5926dc85e3ac6d489ff1efe233c1ea91c8b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://composer.wp.dsd.io/dist/ministryofjustice/cookie-compliance-for-wordpress/ministryofjustice-cookie-compliance-for-wordpress-cb04cfb9e912d780f176747dbd6796fb0741f738-zip-d7164c.zip",
-                "reference": "cb04cfb9e912d780f176747dbd6796fb0741f738",
-                "shasum": "0c89ea4ab1046876a0aeed7c11377f46aa1e045c"
+                "url": "https://api.github.com/repos/ministryofjustice/cookie-compliance-for-wordpress/zipball/ee7d5926dc85e3ac6d489ff1efe233c1ea91c8b1",
+                "reference": "ee7d5926dc85e3ac6d489ff1efe233c1ea91c8b1",
+                "shasum": ""
             },
             "require": {
                 "composer/installers": "^1.0"
@@ -342,24 +342,24 @@
             ],
             "description": "WP plugin that presents visitor with a cookie consent banner and opt-out setting page.",
             "support": {
-                "source": "https://github.com/ministryofjustice/cookie-compliance-for-wordpress/tree/1.3.2",
+                "source": "https://github.com/ministryofjustice/cookie-compliance-for-wordpress/tree/variant-a",
                 "issues": "https://github.com/ministryofjustice/cookie-compliance-for-wordpress/issues"
             },
-            "time": "2019-12-23T20:06:00+00:00"
+            "time": "2020-07-08T16:14:17+00:00"
         },
         {
             "name": "ministryofjustice/wp-moj-components",
-            "version": "3.2.1",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ministryofjustice/wp-moj-components.git",
-                "reference": "f80ad1cda3dd9c01d74b02e11e021e5cb6f0b1e0"
+                "reference": "1f728c926cedc5afdea53272e7b97a4fab3dc511"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://composer.wp.dsd.io/dist/ministryofjustice/wp-moj-components/ministryofjustice-wp-moj-components-f80ad1cda3dd9c01d74b02e11e021e5cb6f0b1e0-zip-64d040.zip",
-                "reference": "f80ad1cda3dd9c01d74b02e11e021e5cb6f0b1e0",
-                "shasum": "b518ee7bd19ade64c1daccf83aa7d630516a863e"
+                "url": "https://composer.wp.dsd.io/dist/ministryofjustice/wp-moj-components/ministryofjustice-wp-moj-components-1f728c926cedc5afdea53272e7b97a4fab3dc511-zip-bac561.zip",
+                "reference": "1f728c926cedc5afdea53272e7b97a4fab3dc511",
+                "shasum": "91a18cb80496bd67dee0e9ee6c3595ef4afb6924"
             },
             "require": {
                 "composer/installers": "^1.0"
@@ -394,10 +394,10 @@
             ],
             "description": "A plugin to introduce global functions to a collection of WP sites",
             "support": {
-                "source": "https://github.com/ministryofjustice/wp-moj-components/tree/3.2.1",
+                "source": "https://github.com/ministryofjustice/wp-moj-components/tree/3.2.2",
                 "issues": "https://github.com/ministryofjustice/wp-moj-components/issues"
             },
-            "time": "2020-06-30T11:26:21+00:00"
+            "time": "2020-07-02T09:16:23+00:00"
         },
         {
             "name": "ministryofjustice/wp-rewrite-media-to-s3",
@@ -848,7 +848,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "ministryofjustice/cookie-compliance-for-wordpress": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/web/app/themes/ccrc/assets/css/editor-style.css
+++ b/web/app/themes/ccrc/assets/css/editor-style.css
@@ -196,7 +196,6 @@ th {
   box-sizing: border-box;
 }
 html {
-  font-size: 10px;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 body {

--- a/web/app/themes/ccrc/base.php
+++ b/web/app/themes/ccrc/base.php
@@ -1,5 +1,4 @@
 <?php get_template_part('head'); ?>
-<body <?php body_class(); ?>>
 
   <!--[if lt IE 8]>
     <div class="alert alert-warning">
@@ -10,6 +9,8 @@
     <!--[if lt IE 9]>
 <link rel="stylesheet" href="<?php bloginfo('template_directory'); ?>/assets/css/ie7and8.css">
   <![endif]-->
+
+  <div class="ccfw-background-grey-overlay"></div>
 
   <?php
     do_action('get_header');

--- a/web/app/themes/ccrc/header.php
+++ b/web/app/themes/ccrc/header.php
@@ -1,4 +1,8 @@
 <?php get_template_part( 'head' ); ?>
+
+<body <?php body_class(); ?>>
+<?php do_action('after_body_open_tag'); ?>
+
 <header class="banner navbar navbar-default navbar-static-top" role="banner">
   <div class="container">
 


### PR DESCRIPTION
CCRC will be used for the cookie banner experiment, and will host variant A. Some changes needed to be made to the base theme, to pull it in and display it. This commit makes those changes. This includes adding a tag into the base file, and altering the base pixel size, as it was breaking the Design System component styling.