### PR TITLE
Fix head tag which is broken up by cookie banner tag

### DIFF
--- a/web/app/themes/ccrc/base.php
+++ b/web/app/themes/ccrc/base.php
@@ -10,8 +10,6 @@
 <link rel="stylesheet" href="<?php bloginfo('template_directory'); ?>/assets/css/ie7and8.css">
   <![endif]-->
 
-  <div class="ccfw-background-grey-overlay"></div>
-
   <?php
     do_action('get_header');
     get_header();

--- a/web/app/themes/ccrc/header.php
+++ b/web/app/themes/ccrc/header.php
@@ -1,8 +1,6 @@
-<?php get_template_part( 'head' ); ?>
-
 <body <?php body_class(); ?>>
+<div class="ccfw-background-grey-overlay"></div>
 <?php do_action('after_body_open_tag'); ?>
-
 <header class="banner navbar navbar-default navbar-static-top" role="banner">
   <div class="container">
 


### PR DESCRIPTION
One of the cookie banner tags is cutting into the head element. This is to alter the order of things being called in, so this doesn't happen.